### PR TITLE
fix: address cubic review feedback on keras metadata and regression t…

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -37,14 +37,14 @@ jobs:
         if: runner.os == 'Linux'
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::keras
           needs: check
 
       - name: Install package dependencies
         if: runner.os != 'Linux'
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::keras
           needs: check
 
       - name: Run R CMD check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::devtools
+          extra-packages: any::rcmdcheck, any::devtools, any::keras
           needs: check
 
       - name: Build source package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Depends: R (>= 4.1)
 Imports: dplyr, tibble, ppclust, Metrics, glue, ggplot2
-Suggests: testthat (>= 3.0.0)
-Enhances: keras
+Suggests: testthat (>= 3.0.0), keras
 Config/testthat/edition: 3
 LazyData: true
 RoxygenNote: 7.3.1

--- a/tests/testthat/test-outlier_mahalanobis.R
+++ b/tests/testthat/test-outlier_mahalanobis.R
@@ -19,7 +19,7 @@ test_that("singular covariance is tracked through the singular_clusters attribut
   res <- detect_outliers_mahalanobis(d, alpha = 0.8)
   info <- attr(res, "singular_clusters")
   expect_equal(info[["1"]], "regularized")
-  expect_equal(length(res$outlier), 5)
+  expect_equal(res$outlier, rep(FALSE, 5))
 })
 
 test_that("undersized cluster (< p+1 rows) is skipped with warning", {
@@ -48,7 +48,7 @@ test_that("regularized clusters are tracked in singular_clusters attribute", {
   res <- detect_outliers_mahalanobis(d, alpha = 0.8)
   info <- attr(res, "singular_clusters")
   expect_true(info[["1"]] %in% c("regularized", "diagonal_fallback"))
-  expect_equal(length(res$outlier), 5)
+  expect_equal(res$outlier, rep(FALSE, 5))
 })
 
 test_that("multi-cluster handling: healthy cluster unaffected by singular sibling", {


### PR DESCRIPTION
…ests

## Summary

- Describe the main change.
- Link the issue or milestone if relevant.

## Changes

- What was added, changed, or removed?
- Note any user-visible behavior changes.

## Testing

- [ ] `Rscript -e "testthat::test_dir('tests/testthat', reporter = 'summary')"`
- [ ] Other relevant verification steps documented below

## Risks

- Describe regressions, compatibility concerns, or follow-up work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `keras` to `Suggests` and install it in CI, and tighten Mahalanobis outlier regression tests to assert the exact logical vector. This addresses review feedback and makes checks consistent across runners.

- **Dependencies**
  - Moved `keras` from `Enhances` to `Suggests` in DESCRIPTION.
  - Added `any::keras` to `r-lib/actions/setup-r-dependencies` in `r-cmd-check` and `release` workflows.

- **Bug Fixes**
  - Updated `test-outlier_mahalanobis.R` to expect `res$outlier` as `rep(FALSE, 5)` instead of a length-only check.

<sup>Written for commit 38b3b3e1b634101343535f34751c692ec1039a93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

