### PR TITLE
fix: make metric evaluation robust to zero-power observations

### DIFF
--- a/R/utils_metrics.R
+++ b/R/utils_metrics.R
@@ -6,9 +6,25 @@ evaluate_metrics <- function(data) {
   stopifnot(all(c("power", "pred") %in% names(data)))
   rmse_val <- Metrics::rmse(data$power, data$pred)
   mae_val  <- Metrics::mae(data$power, data$pred)
-  mape_val <- Metrics::mape(data$power, data$pred)
-  r2_val   <- 1 - sum((data$power - data$pred)^2) /
-                    sum((data$power - mean(data$power))^2)
-  CA <- (1 / 3) * ((1 / (1 + rmse_val)) + (1 / (1 + mape_val)) + r2_val)
+  nonzero_power <- data$power != 0
+  mape_val <- if (any(nonzero_power)) {
+    Metrics::mape(data$power[nonzero_power], data$pred[nonzero_power])
+  } else {
+    NA_real_
+  }
+  r2_denom <- sum((data$power - mean(data$power))^2)
+  r2_val <- if (r2_denom > 0) {
+    1 - sum((data$power - data$pred)^2) / r2_denom
+  } else {
+    NA_real_
+  }
+  ca_components <- c(1 / (1 + rmse_val))
+  if (!is.na(r2_val)) {
+    ca_components <- c(ca_components, r2_val)
+  }
+  if (!is.na(mape_val)) {
+    ca_components <- c(ca_components, 1 / (1 + mape_val))
+  }
+  CA <- mean(ca_components)
   list(RMSE = rmse_val, MAE = mae_val, MAPE = mape_val, R2 = r2_val, CA = CA)
 }

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ list(
 ```
 
 **Combined Accuracy (CA)** aggregates normalized RMSE, MAPE, and R² into a bounded index in `[0, 1]`.
-
-Current limitation: `MAPE` and `CA` may become undefined when observed power contains zeros, because zero-safe metric handling has not been implemented yet.
+When observed power contains zeros, `MAPE` is computed on the non-zero subset so the metric layer remains finite on typical SCADA data.
 
 ---
 

--- a/tests/testthat/test-utils_metrics.R
+++ b/tests/testthat/test-utils_metrics.R
@@ -18,7 +18,7 @@ test_that("evaluate_metrics requires power and pred columns", {
   )
 })
 
-test_that("evaluate_metrics currently returns NaN for zero-power MAPE regression", {
+test_that("evaluate_metrics handles zero-power observations without returning NaN", {
   d <- data.frame(
     power = c(0, 100, 200),
     pred = c(0, 110, 190)
@@ -26,6 +26,18 @@ test_that("evaluate_metrics currently returns NaN for zero-power MAPE regression
 
   metrics <- evaluate_metrics(d)
 
-  expect_true(is.nan(metrics$MAPE))
-  expect_true(is.nan(metrics$CA))
+  expect_equal(metrics$MAPE, Metrics::mape(c(100, 200), c(110, 190)))
+  expect_true(is.finite(metrics$CA))
+})
+
+test_that("evaluate_metrics returns NA for MAPE when all observed power is zero", {
+  d <- data.frame(
+    power = c(0, 0, 0),
+    pred = c(0, 5, 10)
+  )
+
+  metrics <- evaluate_metrics(d)
+
+  expect_true(is.na(metrics$MAPE))
+  expect_true(is.finite(metrics$CA))
 })


### PR DESCRIPTION
## Summary

- Fixes #1
- Link the issue or milestone if relevant.

## Changes

- What was added, changed, or removed?
- Note any user-visible behavior changes.

## Testing

- [ ] `Rscript -e "testthat::test_dir('tests/testthat', reporter = 'summary')"`
- [ ] Other relevant verification steps documented below

## Risks

- Describe regressions, compatibility concerns, or follow-up work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes metric evaluation robust to zero-power observations. MAPE skips zeros, R² is guarded for constant targets, and CA stays finite by averaging available components.

- **Bug Fixes**
  - Compute `MAPE` on non-zero `power`; return NA if all values are zero.
  - Guard `R²` when `power` variance is zero; return NA instead of NaN.
  - Build `CA` as the mean of available components (`1/(1+RMSE)`, `R²`, `1/(1+MAPE)`), keeping it finite.
  - Updated tests with `testthat` and README to reflect the new behavior.

<sup>Written for commit 8e6d4be9817b31b5c4592ac671da8929884b06f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

